### PR TITLE
Fix JS loading on post pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -102,7 +102,7 @@ layout: default
 	</div>
 </div>
 
-<script src="/js/main.js"></script>
+<script src="{{ site.baseurl }}/js/main.js"></script>
 
 <script>
 	var headings = document.querySelectorAll("h2[id]");


### PR DESCRIPTION
When hosting a site under a directory (having baseurl set), the
JavaScript wasn't loading on post pages due to the baseurl not being
prefixed.